### PR TITLE
group demos in sidebar, make partner app background gray, add wealth …

### DIFF
--- a/js/DemoApplication.jsx
+++ b/js/DemoApplication.jsx
@@ -48,37 +48,35 @@ import ImplementPlanApiDemo from './pages/ImplementPlanApiDemo';
 import { hasSession, endSession, startSession } from 'nextcapital-client';
 
 // Defines the set of demos in the app. Combines a route, display name, and page component.
-const demos = [
-  {
-    path: 'doc-vault',
-    name: 'Embedded Doc Vault',
-    component: EmbeddedDocVault
-  },
-  {
-    path: 'implement-plan',
-    name: 'Embedded Implement Plan',
-    component: EmbeddedImplementDemo
-  },
-  {
-    path: 'quick-plan',
-    name: 'Embedded Mini App',
-    component: EmbeddedMiniAppDemo
-  },
-  {
-    path: 'questionnaire',
-    name: 'Embedded Profile Questionnaire',
-    component: EmbeddedQuestionnaire
-  },
+const embeddedAppApiDemos = [
   {
     path: 'embedded-charts',
-    name: 'Embedded Forecast Charts',
+    name: 'Forecast Charts',
     component: EmbeddedForecastCharts
   },
   {
-    path: 'copy-debugger',
-    name: 'Copy Debugger',
-    component: CopyDebugger
+    path: 'quick-plan',
+    name: 'Planning & Advice',
+    component: EmbeddedMiniAppDemo
   },
+  {
+    path: 'implement-plan',
+    name: 'Implement Plan',
+    component: EmbeddedImplementDemo
+  },
+  {
+    path: 'doc-vault',
+    name: 'Doc Vault',
+    component: EmbeddedDocVault
+  },
+  {
+    path: 'questionnaire',
+    name: 'Profile Questionnaire',
+    component: EmbeddedQuestionnaire
+  }
+];
+
+const dataApiDemos = [
   {
     path: 'api-profile',
     name: 'Basic Profile API',
@@ -95,6 +93,11 @@ const demos = [
     component: ForecastApiDemo
   },
   {
+    path: 'api-implement-plan',
+    name: 'Implement Plan API',
+    component: ImplementPlanApiDemo
+  },
+  {
     path: 'api-doc-vault',
     name: 'Documents API',
     component: DocumentApiDemo
@@ -103,13 +106,18 @@ const demos = [
     path: 'api-model-updates',
     name: 'Basic Model Updates',
     component: BasicModelUpdateDemo
-  },
-  {
-    path: 'api-implement-plan',
-    name: 'Implement Plan API',
-    component: ImplementPlanApiDemo
   }
 ];
+
+const miscDemos = [
+  {
+    path: 'copy-debugger',
+    name: 'Copy Debugger',
+    component: CopyDebugger
+  }
+];
+
+const demos = embeddedAppApiDemos.concat(dataApiDemos, miscDemos);
 
 class DemoApplication extends React.Component {
   constructor(props) {
@@ -167,16 +175,43 @@ class DemoApplication extends React.Component {
       <div className="demo-sidebar">
         { this.renderSidebarTop() }
         <div className="sidebar-links">
-        {
-          _.map(demos, (demo) => (
-            <Link
-              key={ demo.path }
-              to={ `/demos/${demo.path}` }
-            >
-              { demo.name }
-            </Link>
-          ))
-        }
+          <h3>Embedded App API Demos</h3>
+          {
+            _.map(embeddedAppApiDemos, (demo) => (
+              <Link
+                key={ demo.path }
+                to={ `/demos/${demo.path}` }
+              >
+                { demo.name }
+              </Link>
+            ))
+          }
+        </div>
+        <div className="sidebar-links">
+          <h3>Data API Demos</h3>
+          {
+            _.map(dataApiDemos, (demo) => (
+              <Link
+                key={ demo.path }
+                to={ `/demos/${demo.path}` }
+              >
+                { demo.name }
+              </Link>
+            ))
+          }
+        </div>
+        <div className="sidebar-links">
+          <h3>Misc Demos</h3>
+          {
+            _.map(miscDemos, (demo) => (
+              <Link
+                key={ demo.path }
+                to={ `/demos/${demo.path}` }
+              >
+                { demo.name }
+              </Link>
+            ))
+          }
         </div>
       </div>
     );

--- a/js/pages/EmbeddedMiniAppDemo.jsx
+++ b/js/pages/EmbeddedMiniAppDemo.jsx
@@ -50,7 +50,7 @@ class EmbeddedMiniAppDemo extends React.Component {
   render() {
     return (
       <Page
-        title="Embedded Mini App"
+        title="Planning & Advice"
         fullScreen
       >
         { EmbeddedMiniApp.render() }

--- a/js/pages/ForecastAPIDemo.jsx
+++ b/js/pages/ForecastAPIDemo.jsx
@@ -93,6 +93,8 @@ class ForecastApiDemo extends React.Component {
     this.console.log(`forecast wealth at retirement: ${forecast.wealthAtRetirement}`);
     this.console.log(`sustainable income: ${forecast.incomeAtRetirement}`);
     this.console.log(`target spending: ${forecast.targetSpending}`);
+    this.console.log(`wealth projection: ${JSON.stringify(forecast.preferredWealthOverTime)}`);
+    this.console.log(`income projection: ${JSON.stringify(forecast.getGroupedIncomeProjectionsInRetirement())}`);
 
     // Find the advice expense
     this.console.log('getting forecast advice expense....'); // technically, already loaded

--- a/styles/demo.scss
+++ b/styles/demo.scss
@@ -50,9 +50,10 @@ body {
     > .sidebar-links {
       display: flex;
       flex-direction: column;
+      margin-bottom: 20px;
 
       > a {
-        margin-bottom: 6px;
+        margin-top: 8px;
       }
     }
   }
@@ -84,7 +85,7 @@ body {
     align-items: center;
     justify-content: center;
     border-bottom: 1px solid #555;
-
+    background-color: #eee;
     font-size: 28pt;
   }
 
@@ -130,11 +131,13 @@ body {
 .demo-simple-card {
   border-radius: 6px;
   border: 1px solid #555;
+  background-color: #fff;
 
   > .simple-card-header {
     font-size: 14pt;
     padding: 8px 12px;
     border-bottom: 1px solid #555;
+    background-color: #eee;
   }
 
   > .simple-card-content {
@@ -147,6 +150,7 @@ body {
   grid-template-columns: 1fr 1fr;
   grid-auto-rows: 350px;
   gap: 24px;
+  background-color: #eee;
 
   @media (max-width: 600px) {
     grid-template-columns: 1fr;


### PR DESCRIPTION
- group demos in sidebar 
- make partner app background gray (header, page/card headers for forecast chart demo)
- add wealth & incomes series to forecast API demo