### PR TITLE
changes to better support demoing with jwt auth

### DIFF
--- a/server/session.js
+++ b/server/session.js
@@ -43,9 +43,9 @@ const Session = {
 
     // otherwise, get a new one using the command-line args
     if (args.jwt) {
-      this.token = this.jwtExchange(args.jwt);
+      this.token = await this.jwtExchange(args.jwt);
     } else {
-      this.token = this.credentialLogin(args.username, args.password);
+      this.token = await this.credentialLogin(args.username, args.password);
     }
 
     return this.token;
@@ -80,10 +80,13 @@ const Session = {
    * @return {Promise<string>}
    */
   async jwtExchange(jwt) {
+    const converted = Buffer.from(jwt.split('.')[1], 'base64').toString('ascii');
+    const iss = JSON.parse(converted).iss; // client_id must match issuer
+
     const authResponse = await this._makeURLEncodedAuthRequest({
       grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
       assertion: jwt,
-      client_id: 'componentui'
+      client_id: iss
     });
 
     return authResponse.access_token;


### PR DESCRIPTION
Updates the demo to better support NextCapital Stub Auth. We'll pull the `client_id` from the `iss` of the bearer JWT, since this doesn't match between Auth Stub and actual partner tokens.

<img width="1438" alt="Screen Shot 2021-07-20 at 12 13 29 PM" src="https://user-images.githubusercontent.com/17504011/126367623-1e13eb25-394a-4fbb-9c40-8266cd532b6a.png">
