### PR TITLE
Add support for uat/prod server [FRONT-6298]

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -9,6 +9,7 @@
     "plannable",
     "isn",
     "npx",
+    "ro",
     "uat",
     "unenrollment",
     "unmount",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,8 @@
     "import/no-extraneous-dependencies": 1,
     "import/no-unresolved": "off",
 
+    "no-underscore-dangle": ["error", { "enforceInMethodNames": false, "allowAfterThis": true }],
+
     "react/prop-types": 1
   }
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Simply run `npm install` to install all packages. Once everything is installed, 
 Once the server is running, open `http://localhost:8080` in a browser to view the application.
 
 ## Specifying a Solution and Authentication
+
 When starting the demo application, you will need to provide both params for proxy authentication and a solution to use.
 
 For authentication, you can either provide a `jwt` bearer assertion to exchange or a `username`/`password` combo. For example:
@@ -29,7 +30,11 @@ For authentication, you can either provide a `jwt` bearer assertion to exchange 
 
 By default, the `nextcapital` solution will be used. To use a different solution (eg: `example`), specify one with the `start`.
 
-Since this demo reflects that bleeding-edge state of the NC client, it runs against the SIT environment. It currently does not work against UAT or other upper NextCapital environments.
+Additionally, you may specify an environment with `env`:
+
+- `npm run start -- --solution=nextcapital --jwt=<base64> --env=uat`
+
+By default, the `sit` environment will be used. See [server/environments.json](server/environments.json) for a list available environments.
 
 Not all demos will work with all solutions. If a demo is unsupported for the current solution, a message will display when that demo is selected.
 
@@ -47,6 +52,7 @@ Not all demos will work with all solutions. If a demo is unsupported for the cur
 - The webpack config (`webpack.config.js`) defines how the app is built
 
 ### Server
+
 - The demo express server lives at `server/server.js`
 - The API proxy exists at `server/proxy.js`
 - The minimal session handling live at `server/session.js`

--- a/build-run.js
+++ b/build-run.js
@@ -10,7 +10,7 @@ const args = yargs(hideBin(process.argv))
     alias: 'e',
     type: 'string',
     default: 'sit',
-    describe: 'nextcapital environment to use (sit or development)'
+    describe: 'nextcapital environment to use'
   })
   .option('solution', {
     alias: 's',
@@ -44,15 +44,14 @@ const webpackProcess = spawn(
 
 const authParams = args.jwt ?
   `--jwt ${args.jwt}` :
-  `--username ${args.username} --password ${args.password}`
+  `--username ${args.username} --password ${args.password}`;
 
 // start the actual node/express server
 const expressProcess = spawn(
   'node',
-  `server/server.js ${authParams}`.split(' '),
+  `server/server.js ${authParams} --env ${args.env}`.split(' '),
   { stdio: 'inherit' }
 );
 
 console.log(`\n\nRunning webpack on PID ${webpackProcess.pid} and express on PID ${expressProcess.pid}...`);
 console.log('Use Ctrl-C to exit both.\n\n');
-

--- a/js/index.jsx
+++ b/js/index.jsx
@@ -19,8 +19,7 @@ configure({
     environmentClass: ENVIRONMENT_CLASS[NC_ENV],
     accessType: ENVIRONMENT_ACCESS_TYPE.PROXY,
     trackingEnabled: true,
-    endpoint: '/api',
-    authEndpoint: '/as/token.oauth2'
+    endpoint: '/api'
   },
   solutionId: SOLUTION_ID // set from webpack
 });

--- a/server/args.js
+++ b/server/args.js
@@ -22,4 +22,10 @@ module.exports = yargs(hideBin(process.argv))
     type: 'string',
     describe: 'jwt to use for bearer exchange'
   })
+  .option('env', {
+    alias: 'e',
+    type: 'string',
+    describe: 'backend environment to use for authorization',
+    default: 'sit'
+  })
   .argv;

--- a/server/environments.json
+++ b/server/environments.json
@@ -1,0 +1,18 @@
+{
+  "development": {
+    "authEndpoint": "https://sit-idp.nextcapital.com/as/token.oauth2",
+    "proxyEndpoint": "https://sit-pa.nextcapital.com"
+  },
+  "sit": {
+    "authEndpoint": "https://sit-idp.nextcapital.com/as/token.oauth2",
+    "proxyEndpoint": "https://sit-pa.nextcapital.com"
+  },
+  "uat": {
+    "authEndpoint": "https://uat-idp.nextcapital.com/as/token.oauth2",
+    "proxyEndpoint": "https://uat-pa.nextcapital.com"
+  },
+  "production": {
+    "authEndpoint": "https://prod-idp.nextcapital.com/as/token.oauth2",
+    "proxyEndpoint": "https://prod-pa.nextcapital.com"
+  }
+}

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -1,4 +1,8 @@
+const _ = require('lodash');
 const { createProxyMiddleware } = require('http-proxy-middleware');
+
+const args = require('./args');
+const environments = require('./environments.json');
 
 /**
  * This represents a minimal, bare-bones example of using a proxy to provide auth. In this case:
@@ -20,7 +24,7 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
  * a CSRF token to all requests.
  */
 const apiProxyOptions = {
-  target: 'https://sit-pa.nextcapital.com', // This example code always uses SIT
+  target: _.get(environments, `${args.env}.proxyEndpoint`),
   changeOrigin: true,
   timeout: 1000 * 60 * 5, // 5 minutes, NextCapital's server will timeout first
   proxyTimeout: 1000 * 60 * 5, // 5 minutes, NextCapital's server will timeout first


### PR DESCRIPTION
This PR adds support for uat and production when using `npm run start`, plus additional minor linting fixes.

Tested with:
```
npm run start -- --solution=nextcapital --jwt=<base64>
npm run start -- --solution=nextcapital --jwt=<base64> --env=sit
npm run start -- --solution=nextcapital --jwt=<base64> --env=development
npm run start -- --solution=nextcapital --jwt=<base64> --env=uat
npm run start -- --solution=nextcapital --jwt=<base64> --env=production
```

