### PR TITLE
Support port build arg [FRONT-6311]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .DS_Store
 
 .eslintcache
+.sass-cache

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ By default, the `sit` environment will be used. See [server/environments.json](s
 
 Not all demos will work with all solutions. If a demo is unsupported for the current solution, a message will display when that demo is selected.
 
+## Specifying the Localhost Port and Reload Watching
+
+When starting the demo application, there are additional optional params for specifying the port number and whether to live reload.
+
+- `--port=9000` -> the `nextcapital-client-demo` server will now start on `localhost:9000`.
+  - Defaults to port `8080`
+- `--no-live-reload` -> `nextcapital-client-demo` skips having the build watch for changes with auto reload
+  - The live reload server runs on port 8081 if started
+
+Example: `npm run start -- --solution=nextcapital --username=example@email.com --password=gatherer-2 --port=9090 --no-live-reload`
+
 ## Codebase Overview
 
 ### Client

--- a/build-run.js
+++ b/build-run.js
@@ -12,6 +12,11 @@ const args = yargs(hideBin(process.argv))
     default: 'sit',
     describe: 'nextcapital environment to use'
   })
+  .options('port', {
+    type: 'integer',
+    default: 8080,
+    describe: 'the port number for the localhost'
+  })
   .option('solution', {
     alias: 's',
     type: 'string',
@@ -33,6 +38,12 @@ const args = yargs(hideBin(process.argv))
     type: 'string',
     describe: 'jwt to use for bearer exchange'
   })
+  .option('liveReload', {
+    alias: 'r',
+    type: 'boolean',
+    default: true,
+    describe: 'whether to run the reload server, using port 8081'
+  })
   .argv;
 
 // start a watching webpack process
@@ -49,7 +60,7 @@ const authParams = args.jwt ?
 // start the actual node/express server
 const expressProcess = spawn(
   'node',
-  `server/server.js ${authParams} --env ${args.env}`.split(' '),
+  `server/server.js ${authParams} --env ${args.env} --port ${args.port} --live-reload ${args.liveReload}`.split(' '),
   { stdio: 'inherit' }
 );
 

--- a/js/DemoApplication.jsx
+++ b/js/DemoApplication.jsx
@@ -115,7 +115,7 @@ class DemoApplication extends React.Component {
   /**
    * Renders a helpful link to documentation.
    *
-   * @returns {React.Component}
+   * @returns {React.Component} the right section of the header bar
    */
   renderHeaderRight() {
     return (
@@ -189,7 +189,7 @@ class DemoApplication extends React.Component {
   /**
    * Renders all of the routes for the application.
    *
-   * @returns {React.Component}
+   * @returns {React.Component} the demo application
    */
   render() {
     return (

--- a/server/args.js
+++ b/server/args.js
@@ -28,4 +28,15 @@ module.exports = yargs(hideBin(process.argv))
     describe: 'backend environment to use for authorization',
     default: 'sit'
   })
+  .options('port', {
+    type: 'integer',
+    default: 8080,
+    describe: 'the port number for the localhost'
+  })
+  .option('liveReload', {
+    alias: 'r',
+    type: 'boolean',
+    default: true,
+    describe: 'whether to run the reload server, using port 8081'
+  })
   .argv;

--- a/server/server.js
+++ b/server/server.js
@@ -29,9 +29,11 @@ app.use(express.static(path.resolve(__dirname, '../dist')));
 app.use('/api', Session.middleware.bind(Session), ApiProxy);
 
 // Start the server
-app.listen(8080, () => console.log('server ready on port 8080'));
+app.listen(args.port, () => console.log(`server ready on port ${args.port}`));
 
 // Start LiveReload
-console.log('Livereload is watching files on port 8081...');
-const liveReloadServer = livereload.createServer({ delay: 100, port: 8081 });
-liveReloadServer.watch([path.resolve(__dirname, '../dist')]);
+if (args.liveReload) {
+  console.log('Livereload is watching files on port 8081...');
+  const liveReloadServer = livereload.createServer({ delay: 100, port: 8081 });
+  liveReloadServer.watch([path.resolve(__dirname, '../dist')]);
+}


### PR DESCRIPTION
<!--

🚨 THIS REPO IS PUBLIC! Be careful what you post here. 🚨

-->

This PR expands the `build-run` script to allow configuration of the `port` number, and whether live reload is launched.