### PR TITLE
Allow passing in of access token and proxyEndpoint [NGAGE-203]

### DIFF
--- a/build-run.js
+++ b/build-run.js
@@ -17,6 +17,10 @@ const args = yargs(hideBin(process.argv))
     default: 8080,
     describe: 'the port number for the localhost'
   })
+  .options('proxyEndpoint', {
+    type: 'string',
+    describe: 'the proxyEndpoint. NOTE: When not provided defaults to proxyEndpoint from the environments.json file'
+  })
   .option('solution', {
     alias: 's',
     type: 'string',
@@ -38,6 +42,11 @@ const args = yargs(hideBin(process.argv))
     type: 'string',
     describe: 'jwt to use for bearer exchange'
   })
+  .option('accessToken', {
+    alias: 'a',
+    type: 'string',
+    describe: 'the accessToken for the session. NOTE: Should not be combined with jwt arg'
+  })
   .option('liveReload', {
     alias: 'r',
     type: 'boolean',
@@ -53,14 +62,21 @@ const webpackProcess = spawn(
   { stdio: 'inherit' }
 );
 
-const authParams = args.jwt ?
-  `--jwt ${args.jwt}` :
-  `--username ${args.username} --password ${args.password}`;
+let authParams = '';
+if (args.jwt) {
+  authParams = `--jwt ${args.jwt}`
+} else if (args.accessToken) {
+  authParams = `--accessToken ${args.accessToken}`
+} else if (args.username && args.password) {
+  authParams = `--username ${args.username} --password ${args.password}`;
+}
+
+const proxyEndpoint = args.proxyEndpoint ? `--proxyEndpoint ${args.proxyEndpoint}` : '';
 
 // start the actual node/express server
 const expressProcess = spawn(
   'node',
-  `server/server.js ${authParams} --env ${args.env} --port ${args.port} --live-reload ${args.liveReload}`.split(' '),
+  `server/server.js ${authParams} ${proxyEndpoint} --env ${args.env} --port ${args.port} --live-reload ${args.liveReload}`.split(' '),
   { stdio: 'inherit' }
 );
 

--- a/server/args.js
+++ b/server/args.js
@@ -22,6 +22,11 @@ module.exports = yargs(hideBin(process.argv))
     type: 'string',
     describe: 'jwt to use for bearer exchange'
   })
+  .option('accessToken', {
+    alias: 'a',
+    type: 'string',
+    describe: 'the accessToken for the session. NOTE: Should not be combined with jwt arg'
+  })
   .option('env', {
     alias: 'e',
     type: 'string',
@@ -32,6 +37,10 @@ module.exports = yargs(hideBin(process.argv))
     type: 'integer',
     default: 8080,
     describe: 'the port number for the localhost'
+  })
+  .options('proxyEndpoint', {
+    type: 'string',
+    describe: 'the proxyEndpoint. NOTE: When not provided defaults to proxyEndpoint from the environments.json file'
   })
   .option('liveReload', {
     alias: 'r',

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -4,6 +4,11 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 const args = require('./args');
 const environments = require('./environments.json');
 
+const proxyEndpoint = (
+  args.proxyEndpoint ||
+  _.get(environments, `${args.env}.proxyEndpoint`)
+);
+
 /**
  * This represents a minimal, bare-bones example of using a proxy to provide auth. In this case:
  *
@@ -24,7 +29,7 @@ const environments = require('./environments.json');
  * a CSRF token to all requests.
  */
 const apiProxyOptions = {
-  target: _.get(environments, `${args.env}.proxyEndpoint`),
+  target: proxyEndpoint,
   changeOrigin: true,
   timeout: 1000 * 60 * 5, // 5 minutes, NextCapital's server will timeout first
   proxyTimeout: 1000 * 60 * 5, // 5 minutes, NextCapital's server will timeout first

--- a/server/server.js
+++ b/server/server.js
@@ -8,8 +8,12 @@ const ApiProxy = require('./proxy');
 const Session = require('./session');
 const args = require('./args');
 
-if (!(args.jwt || (args.username && args.password))) {
-  console.error('please provide username/password or jwt');
+if (!(
+  args.jwt ||
+  args.accessToken ||
+  (args.username && args.password)
+)) {
+  console.error('please provide username/password, jwt, or accessToken');
   process.exit(1);
 }
 

--- a/server/session.js
+++ b/server/session.js
@@ -45,6 +45,8 @@ const Session = {
     // otherwise, get a new one using the command-line args
     if (args.jwt) {
       this.token = await this.jwtExchange(args.jwt);
+    } else if (args.accessToken) {
+      this.token = args.accessToken;
     } else {
       this.token = await this.credentialLogin(args.username, args.password);
     }


### PR DESCRIPTION
<!--

🚨 THIS REPO IS PUBLIC! Be careful what you post here. 🚨

-->

This PR expands the available build script args to also allow passing in of an already retrieved `access token` and `proxyEndpoint`.