### PR TITLE
(COPILOT) Upgrade lodash to ^4.18.1 [ENG-17905]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "express": "^4.17.1",
         "http-proxy-middleware": "^3.0.5",
         "livereload": "^0.9.3",
-        "lodash": "^4.17.23",
+        "lodash": "^4.18.1",
         "node-fetch": "^3.3.2",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -8037,9 +8037,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "express": "^4.17.1",
     "http-proxy-middleware": "^3.0.5",
     "livereload": "^0.9.3",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "node-fetch": "^3.3.2",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",


### PR DESCRIPTION
Upgrade lodash from `^4.17.23` to `^4.18.1` to keep dependencies up to date with the latest minor version.

## Related/Required PRs
N/A — standalone dependency upgrade.

## Notes
- Ran `npm install` to update the lockfile
- Verified: lint (clean), build (succeeds)
