### PR TITLE
Move livereload script injection to server-side [ENG-18846]

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const express = require('express');
 const favicon = require('serve-favicon');
@@ -21,6 +22,21 @@ app.disable('x-powered-by');
 // Define overall middleware
 app.use(favicon(path.join(__dirname, '../static/favicon.png'))); // see serve-favicon package docs
 app.use(cookieParser());
+
+// Serve index.html with livereload script injected when live reload is enabled.
+// This must be registered before express.static so it handles '/' first.
+const LIVERELOAD_SCRIPT = '<script src="http://localhost:8081/livereload.js?snipver=1" defer></script>';
+
+app.get('/', (req, res) => {
+  const indexPath = path.resolve(__dirname, '../dist/index.html');
+  let html = fs.readFileSync(indexPath, 'utf8');
+
+  if (args.liveReload) {
+    html = html.replace('</head>', `    ${LIVERELOAD_SCRIPT}\n  </head>`);
+  }
+
+  res.type('html').send(html);
+});
 
 // Setup static assets
 app.use(express.static(path.resolve(__dirname, '../dist')));

--- a/static/index.html
+++ b/static/index.html
@@ -10,9 +10,6 @@
 
     <!-- Our bundled file from webpack. This is our main application. -->
     <script type="text/javascript" src="demo.js" defer></script>
-
-    <!-- This script is needed for livereload. -->
-    <script type="text/javascript" src="http://localhost:8081/livereload.js?snipver=1" defer></script>
   </head>
   <body>
     <!-- The application will replace the content of this node with the react render. -->


### PR DESCRIPTION
Remove the hardcoded livereload script tag from static/index.html. Instead, inject it server-side in the Express route handler for '/' only when --live-reload is enabled.

This fixes two issues when used with browser-testing-framework:
- ERR_CONNECTION_REFUSED when livereload server is not running
- Port 8081 collision with thread-indexed Express ports

Dependent PR: https://github.com/BLC/browser-testing-framework/pull/4922

Tests:
- Tested locally that live reload still worked

<!--

🚨 THIS REPO IS PUBLIC! Be careful what you post here. 🚨

-->


## Related/Required PRs


https://github.com/BLC/browser-testing-framework/pull/4922