### PR TITLE
Upgrade body-parser 1.20.5 → 1.20.6 [VAM-10775]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3923,9 +3923,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",


### PR DESCRIPTION
<!--

🚨 THIS REPO IS PUBLIC! Be careful what you post here. 🚨

-->

## Summary

Upgrades the `body-parser` transitive dependency from **1.20.5** to **1.20.6** to remediate [CVE-2026-12590](https://github.com/expressjs/body-parser/security/advisories/GHSA-v422-hmwv-36x6) (Allocation of Resources Without Limits or Throttling in the `limit` option validation).

**Strategy:** Transitive update via `npm up body-parser`. `body-parser` is pulled in by `express@4.22.2`, whose declared range `~1.20.5` accepts 1.20.6 — no manifest changes required. The upgrade produces a lockfile-only diff (3 lines).

**Verification:**
- `package-lock.json` walked after the upgrade: only `body-parser@1.20.6` remains.
- `body-parser` 1.20.6 is clean on public advisory feeds.
- `npm run lint` passes.
- `npm run build` succeeds.

**Behavior change:** none expected for this repo. The 1.20.6 patch tightens validation of the `limit` option so that unparseable strings and `NaN` now throw at configuration time (previously silently ignored). This repo does not pass a dynamic `limit`, so nothing changes at runtime.

Related ticket: VAM-10775
